### PR TITLE
Set default datacoding to "auto" and add a function to allow datacoding selection when sending messages

### DIFF
--- a/src/MessagebirdClient.php
+++ b/src/MessagebirdClient.php
@@ -35,6 +35,9 @@ class MessagebirdClient
         if (empty($message->recipients)) {
             $message->setRecipients(config('services.messagebird.recipients'));
         }
+        if (empty($message->datacoding)) {
+            $message->setDatacoding('auto');
+        }
 
         try {
             $this->client->request('POST', 'https://rest.messagebird.com/messages', [

--- a/src/MessagebirdMessage.php
+++ b/src/MessagebirdMessage.php
@@ -52,6 +52,14 @@ class MessagebirdMessage
 
         return $this;
     }
+    
+    public function setDatacoding($datacoding)
+    {
+        $this->datacoding = $datacoding;
+
+        return $this;
+    }
+
 
     public function toJson()
     {


### PR DESCRIPTION
The default datacoding of the API is "plain", this is sufficient for English and other languages with unaccented characters but it's problematic when it comes for accented languages like French, Spanish...
These adds will allow to send messages automatically with the best datacoding.
It also becomes possible to manually select datacoding before sending the message.