### PR TITLE
Laravel 8 support and also allow to use Guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/notifications": "^5.5 || ^6.0 || ^7.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0",
         "illuminate/queue": "^5.5 || ^6.0 || ^7.0",
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2 || ^7.0",
         "ext-json": "*"
     },
     "require-dev": {
@@ -38,7 +38,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.2.0"
+            "php": "7.2.5"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "illuminate/notifications": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/queue": "^5.5 || ^6.0 || ^7.0",
+        "illuminate/notifications": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/queue": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
         "ext-json": "*"
     },
@@ -36,10 +36,7 @@
         "test": "vendor/bin/phpunit"
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.2.5"
-        }
+        "sort-packages": true
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
Hello,

we have a other package that soon will need Guzzle ^7.

So I added the possibility here too. It seems that Guzzle 7 has no effect on this package. 
The only problem was it needed php ^7.2.5. But php 7.2 will be end of life in 4 months and only receive security updates until then.

Also added PHP 7.4 to the travis matrix.
 