### PR TITLE
Register "messagebird" as channel instead of using the class name

### DIFF
--- a/src/MessagebirdServiceProvider.php
+++ b/src/MessagebirdServiceProvider.php
@@ -26,7 +26,7 @@ class MessagebirdServiceProvider extends ServiceProvider
                 return new MessagebirdClient(new Client(), $config['access_key']);
             });
         
-        $this->app[ChannelManager::class]->extend('messagebird', function($app) {
+        $this->app[ChannelManager::class]->extend('messagebird', function ($app) {
             return $app->make(MessagebirdChannel::class);
         });
     }

--- a/src/MessagebirdServiceProvider.php
+++ b/src/MessagebirdServiceProvider.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Messagebird;
 
 use GuzzleHttp\Client;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\ServiceProvider;
 use NotificationChannels\Messagebird\Exceptions\InvalidConfiguration;
 
@@ -24,5 +25,9 @@ class MessagebirdServiceProvider extends ServiceProvider
 
                 return new MessagebirdClient(new Client(), $config['access_key']);
             });
+        
+        $this->app[ChannelManager::class]->extend('messagebird', function($app) {
+            return $app->make(MessagebirdChannel::class);
+        });
     }
 }

--- a/src/MessagebirdServiceProvider.php
+++ b/src/MessagebirdServiceProvider.php
@@ -25,7 +25,7 @@ class MessagebirdServiceProvider extends ServiceProvider
 
                 return new MessagebirdClient(new Client(), $config['access_key']);
             });
-        
+
         $this->app[ChannelManager::class]->extend('messagebird', function ($app) {
             return $app->make(MessagebirdChannel::class);
         });


### PR DESCRIPTION
This PR aligns with #32 and should really be the only way to reference in `via()`:

```php
public function via($notifiable)
{
    return ['messagebird'];
}
```