### PR TITLE
Fix PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0|^8.1",
         "illuminate/notifications": "^9.0",
         "illuminate/support": "^9.0",
         "illuminate/queue": "^9.0",


### PR DESCRIPTION
Fixes #37.

According to the [support policy](https://laravel.com/docs/9.x/releases#support-policy), Laravel 9 also support PHP 8.0. If you're on Laravel 9 and PHP 8.0, you cannot install this package anymore with any version because of the following errors (I'm trying to install 3.0 here):
```
Your requirements could not be resolved to an installable set of packages.
    - illuminate/support[v6.0.0, ..., v6.19.1] require php ^7.2 -> your php version (8.0.15) does not satisfy that requirement.
    - illuminate/support[v7.0.0, ..., v7.28.4] require php ^7.2.5 -> your php version (8.0.15) does not satisfy that requirement.       
    - illuminate/support[v6.0.0, ..., v6.19.1] require php ^7.2 -> your php version (8.0.15) does not satisfy that requirement.
    - illuminate/support[v7.0.0, ..., v7.28.4] require php ^7.2.5 -> your php version (8.0.15) does not satisfy that requirement.
    - illuminate/support[v8.0.0, ..., v8.11.2] require php ^7.3 -> your php version (8.0.15) does not satisfy that requirement.
    - Root composer.json requires laravel-notification-channels/messagebird ^3 -> satisfiable by laravel-notification-channels/messagebird[v3.0.0].
    - Conclusion: don't install laravel/framework v9.14.1 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.14.0 (conflict analysis result)
    - laravel-notification-channels/messagebird v3.0.0 requires illuminate/support ^5.5 || ^6.0 || ^7.0 || ^8.0 -> satisfiable by illuminate/support[v5.5.0, ..., 5.8.x-dev, v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev].
    - Only one of these can be installed: illuminate/support[dev-master, v5.0.0, ..., 5.8.x-dev, v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev, v9.0.0-beta.1, ..., 9.x-dev], laravel/framework[v9.14.0, v9.14.1, 9.x-dev]. laravel/framework replaces illuminate/support and thus cannot coexist with it.
    - Root composer.json requires laravel/framework ^9.14 -> satisfiable by laravel/framework[v9.14.0, v9.14.1, 9.x-dev].
```