### PR TITLE
Pass notification instance to routeNotificationFor call

### DIFF
--- a/src/MessagebirdChannel.php
+++ b/src/MessagebirdChannel.php
@@ -22,8 +22,8 @@ class MessagebirdChannel
     /**
      * Send the given notification.
      *
-     * @param mixed $notifiable
-     * @param \Illuminate\Notifications\Notification $notification
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
      *
      * @return object with response body data if succesful response from API | empty array if not
      * @throws \NotificationChannels\MessageBird\Exceptions\CouldNotSendNotification

--- a/src/MessagebirdChannel.php
+++ b/src/MessagebirdChannel.php
@@ -38,7 +38,7 @@ class MessagebirdChannel
             $message = MessagebirdMessage::create($message);
         }
 
-        if ($to = $notifiable->routeNotificationFor('messagebird')) {
+        if ($to = $notifiable->routeNotificationFor('messagebird', $notification)) {
             $message->setRecipients($to);
         }
 

--- a/src/MessagebirdChannel.php
+++ b/src/MessagebirdChannel.php
@@ -24,8 +24,8 @@ class MessagebirdChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     *
      * @return object with response body data if succesful response from API | empty array if not
+     *
      * @throws \NotificationChannels\MessageBird\Exceptions\CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)

--- a/src/MessagebirdMessage.php
+++ b/src/MessagebirdMessage.php
@@ -8,6 +8,7 @@ class MessagebirdMessage
     public $originator;
     public $recipients;
     public $reference;
+    public $datacoding;
     public $reportUrl;
 
     public static function create($body = '')


### PR DESCRIPTION
You can pass the notification instance to the `routeNotificationFor` call, so you can do this in your `User` model:

```php
public function routeNotificationForMessagebird(Notification $notification)
{
    //
}
```

Previously, `null` was always passed to this method.

There was also a deprecation warning from PHP about the creation of dynamic properties.